### PR TITLE
CloudFrontとAPI GatewayのWAFを作成

### DIFF
--- a/ap-northeast-1/dev/api_gateway.tf
+++ b/ap-northeast-1/dev/api_gateway.tf
@@ -224,9 +224,8 @@ resource "aws_api_gateway_integration" "options" {
   ]
 }
 
-resource "aws_api_gateway_deployment" "dev" {
+resource "aws_api_gateway_deployment" "main" {
   rest_api_id = aws_api_gateway_rest_api.main.id
-  stage_name  = var.env
 
   depends_on = [
     aws_api_gateway_integration.get,
@@ -235,4 +234,15 @@ resource "aws_api_gateway_deployment" "dev" {
     aws_api_gateway_integration.delete_id,
     aws_api_gateway_integration.options,
   ]
+}
+
+resource "aws_api_gateway_stage" "main" {
+  cache_cluster_enabled = false
+  deployment_id         = aws_api_gateway_deployment.main.id
+  rest_api_id           = aws_api_gateway_rest_api.main.id
+  stage_name            = var.env
+  tags                  = {}
+  tags_all              = {}
+  variables             = {}
+  xray_tracing_enabled  = false
 }

--- a/ap-northeast-1/dev/backend.tf
+++ b/ap-northeast-1/dev/backend.tf
@@ -2,6 +2,11 @@ provider "aws" {
   region = "ap-northeast-1"
 }
 
+provider "aws" {
+  region = "us-east-1"
+  alias  = "virginia"
+}
+
 terraform {
   required_version = ">= 0.15"
   required_providers {

--- a/ap-northeast-1/dev/cloudfront.tf
+++ b/ap-northeast-1/dev/cloudfront.tf
@@ -9,6 +9,7 @@ resource "aws_cloudfront_distribution" "main" {
   tags                = {}
   tags_all            = {}
   wait_for_deployment = true
+  web_acl_id          = aws_wafv2_web_acl.cloudfront.arn
 
   default_cache_behavior {
     allowed_methods = [
@@ -100,6 +101,7 @@ resource "aws_cloudfront_distribution" "main" {
     aws_s3_bucket.cloudfront_logs,
     aws_s3_bucket_public_access_block.cloudfront_access_block,
     aws_s3_bucket_acl.cloudfront_acl,
-    aws_s3_bucket_ownership_controls.main
+    aws_s3_bucket_ownership_controls.main,
+    aws_wafv2_web_acl.cloudfront
   ]
 }

--- a/ap-northeast-1/dev/cloudfront.tf
+++ b/ap-northeast-1/dev/cloudfront.tf
@@ -63,7 +63,7 @@ resource "aws_cloudfront_distribution" "main" {
     connection_timeout  = 10
     domain_name         = "${aws_api_gateway_rest_api.main.id}.execute-api.${var.region}.amazonaws.com"
     origin_id           = "${aws_api_gateway_rest_api.main.id}.execute-api.${var.region}.amazonaws.com"
-    origin_path         = "/${aws_api_gateway_deployment.dev.stage_name}"
+    origin_path         = "/${aws_api_gateway_stage.main.stage_name}"
 
     custom_origin_config {
       http_port                = 80

--- a/ap-northeast-1/dev/waf.tf
+++ b/ap-northeast-1/dev/waf.tf
@@ -271,3 +271,8 @@ resource "aws_wafv2_web_acl" "apigateway" {
     sampled_requests_enabled   = true
   }
 }
+
+resource "aws_wafv2_web_acl_association" "apigateway" {
+  resource_arn = "arn:aws:apigateway:${var.region}::/restapis/${aws_api_gateway_stage.main.rest_api_id}/stages/${aws_api_gateway_stage.main.stage_name}"
+  web_acl_arn  = aws_wafv2_web_acl.apigateway.arn
+}

--- a/ap-northeast-1/dev/waf.tf
+++ b/ap-northeast-1/dev/waf.tf
@@ -1,0 +1,273 @@
+resource "aws_wafv2_web_acl" "cloudfront" {
+  provider = aws.virginia
+
+  description   = "${var.env}-waf-acl-of-cloudfront"
+  name          = "${var.env}-waf-acl-of-cloudfront"
+  scope         = "CLOUDFRONT"
+  tags          = {}
+  tags_all      = {}
+  token_domains = []
+
+  default_action {
+    allow {
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+    priority = 1
+
+    override_action {
+
+      none {}
+    }
+
+    statement {
+
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "AWS-AWSManagedRulesAnonymousIpList"
+    priority = 2
+
+    override_action {
+
+      none {}
+    }
+
+    statement {
+
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAnonymousIpList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAnonymousIpList"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 0
+
+    override_action {
+
+      none {}
+    }
+
+    statement {
+
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 3
+
+    override_action {
+
+      none {}
+    }
+
+    statement {
+
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "AWS-AWSManagedRulesSQLiRuleSet"
+    priority = 4
+
+    override_action {
+
+      none {}
+    }
+
+    statement {
+
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesSQLiRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.env}-waf-acl-of-cloudfront"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl" "apigateway" {
+  description   = "${var.env}-waf-acl-of-apigateway"
+  name          = "${var.env}-waf-acl-of-apigateway"
+  scope         = "REGIONAL"
+  tags          = {}
+  tags_all      = {}
+  token_domains = []
+
+  default_action {
+    allow {
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+    priority = 1
+
+    override_action {
+
+      none {}
+    }
+
+    statement {
+
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "AWS-AWSManagedRulesAnonymousIpList"
+    priority = 2
+
+    override_action {
+
+      none {}
+    }
+
+    statement {
+
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAnonymousIpList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAnonymousIpList"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 0
+
+    override_action {
+
+      none {}
+    }
+
+    statement {
+
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 3
+
+    override_action {
+
+      none {}
+    }
+
+    statement {
+
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "AWS-AWSManagedRulesSQLiRuleSet"
+    priority = 4
+
+    override_action {
+
+      none {}
+    }
+
+    statement {
+
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesSQLiRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.env}-waf-acl-of-apigateway"
+    sampled_requests_enabled   = true
+  }
+}


### PR DESCRIPTION
## 概要
CloudFrontとAPI GatewayのWAFを作成

## 追加した設定
- WebACLに以下の設定を追加
  - AWS-AWSManagedRulesCommonRuleSet(Webアプリケーションに対する攻撃のコアルール)
  - AWS-AWSManagedRulesAmazonIpReputationList(Amazon IP評価リストに関するルール)
  - AWS-AWSManagedRulesAnonymousIpList(匿名IPリストに関するルール)
  - AWS-AWSManagedRulesKnownBadInputsRuleSet(不正なインプットデータに関するルール)
  - AWS-AWSManagedRulesSQLiRuleSet(SQLインジェクションに関するルール)

## API Gatewayに対するWAF追加後の挙動確認
- クロスサイトスクリプティングのテスト
<img width="1436" alt="スクリーンショット 2023-07-09 21 43 49" src="https://github.com/yusa0730/terraform_renewal_plot_version/assets/37875540/0e5188d6-6612-486b-aad3-30d4632ec389">

- SQLインジェクションのテスト
<img width="1387" alt="スクリーンショット 2023-07-09 21 47 33" src="https://github.com/yusa0730/terraform_renewal_plot_version/assets/37875540/015deb3e-5323-46a2-9e97-8de161be0d3e">

## CloudFrontに対するWAF追加後の挙動確認

- クロスサイトスクリプティングのテスト
<img width="1428" alt="スクリーンショット 2023-07-09 15 21 08" src="https://github.com/yusa0730/terraform_renewal_plot_version/assets/37875540/8e304cc4-f6de-4acd-a997-5fcb1f149d74">

- SQLインジェクションのテスト
<img width="1435" alt="スクリーンショット 2023-07-09 15 18 29" src="https://github.com/yusa0730/terraform_renewal_plot_version/assets/37875540/b0fb5fb1-4e13-43d7-82a6-622d9c9fa46a">
