### PR TITLE
DynamoDBに対するAWS Backupの構築

### DIFF
--- a/ap-northeast-1/dev/aws_backup.tf
+++ b/ap-northeast-1/dev/aws_backup.tf
@@ -1,0 +1,61 @@
+resource "aws_backup_plan" "main" {
+  name = "${var.env}-backup-plan"
+  tags = {
+    "Name" = "${var.env}-backup-plan"
+  }
+  tags_all = {
+    "Name" = "${var.env}-backup-plan"
+  }
+
+  rule {
+    completion_window        = 120
+    enable_continuous_backup = true
+    recovery_point_tags      = {}
+    rule_name                = "${var.env}-backup-rule"
+    schedule                 = "cron(0 19 ? * * *)"
+    start_window             = 60
+    target_vault_name        = aws_backup_vault.main.name
+
+    copy_action {
+      destination_vault_arn = aws_backup_vault.destination.arn
+    }
+
+    lifecycle {
+      cold_storage_after = 0
+      delete_after       = 35
+    }
+  }
+}
+
+resource "aws_backup_vault" "main" {
+  kms_key_arn = aws_kms_key.backup_vault.arn
+  name        = "${var.env}-backup-vault"
+
+  tags = {
+    "Name" = "${var.env}-backup-vault"
+  }
+  tags_all = {
+    "Name" = "${var.env}-backup-vault"
+  }
+}
+
+resource "aws_backup_vault" "destination" {
+  provider    = aws.osaka
+  kms_key_arn = aws_kms_key.destination_backup_vault.arn
+  name        = "${var.env}-destination-backup-vault"
+
+  tags = {
+    "Name" = "${var.env}-destination-backup-vault"
+  }
+  tags_all = {
+    "Name" = "${var.env}-destination-backup-vault"
+  }
+}
+
+resource "aws_backup_selection" "main" {
+  iam_role_arn = aws_iam_role.aws_backup_role.arn
+  name         = "${var.env}-backup-selection"
+  plan_id      = aws_backup_plan.main.id
+
+  resources = ["arn:aws:dynamodb:*:*:table/*"]
+}

--- a/ap-northeast-1/dev/backend.tf
+++ b/ap-northeast-1/dev/backend.tf
@@ -7,6 +7,11 @@ provider "aws" {
   alias  = "virginia"
 }
 
+provider "aws" {
+  region = "ap-northeast-3"
+  alias  = "osaka"
+}
+
 terraform {
   required_version = ">= 0.15"
   required_providers {

--- a/ap-northeast-1/dev/iam.tf
+++ b/ap-northeast-1/dev/iam.tf
@@ -1,3 +1,4 @@
+## Lambda
 resource "aws_iam_role" "lambda_role" {
   name = "${var.env}-lambda-role"
   assume_role_policy = jsonencode({
@@ -46,4 +47,40 @@ resource "aws_iam_role_policy" "lambda_role_policy" {
       }
     ]
   })
+}
+
+## AWS Backup
+resource "aws_iam_role" "aws_backup_role" {
+  name = "AWSBackupDefaultServiceRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "backup.amazonaws.com",
+        },
+      },
+    ],
+  })
+}
+
+data "aws_iam_policy" "aws_backup_service_role_policy_for_backup" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+data "aws_iam_policy" "aws_backup_service_role_policy_for_restore" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+}
+
+resource "aws_iam_role_policy_attachment" "aws_backup" {
+  role       = aws_iam_role.aws_backup_role.name
+  policy_arn = data.aws_iam_policy.aws_backup_service_role_policy_for_backup.arn
+}
+
+resource "aws_iam_role_policy_attachment" "aws_restore" {
+  role       = aws_iam_role.aws_backup_role.name
+  policy_arn = data.aws_iam_policy.aws_backup_service_role_policy_for_restore.arn
 }

--- a/ap-northeast-1/dev/kms.tf
+++ b/ap-northeast-1/dev/kms.tf
@@ -1,0 +1,104 @@
+resource "aws_kms_key" "backup_vault" {
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  description              = "Default key that protects my Backup data when no other key is defined"
+  enable_key_rotation      = true
+  is_enabled               = true
+  key_usage                = "ENCRYPT_DECRYPT"
+  multi_region             = false
+  policy = jsonencode(
+    {
+      Id = "auto-backup-1"
+      Statement = [
+        {
+          Action = [
+            "kms:CreateGrant",
+            "kms:Decrypt",
+            "kms:GenerateDataKey*",
+          ]
+          Condition = {
+            StringEquals = {
+              "kms:CallerAccount" = "${data.aws_caller_identity.current.account_id}"
+              "kms:ViaService"    = "backup.ap-northeast-1.amazonaws.com"
+            }
+          }
+          Effect = "Allow"
+          Principal = {
+            AWS = "*"
+          }
+          Resource = "*"
+          Sid      = "Allow access through Backup for all principals in the account that are authorized to use Backup Storage"
+        },
+        {
+          Action = [
+            "kms:Describe*",
+            "kms:Get*",
+            "kms:List*",
+            "kms:RevokeGrant",
+          ]
+          Effect = "Allow"
+          Principal = {
+            AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+          }
+          Resource = "*"
+          Sid      = "Allow direct access to key metadata to the account"
+        },
+      ]
+      Version = "2012-10-17"
+    }
+  )
+  tags     = {}
+  tags_all = {}
+}
+
+resource "aws_kms_key" "destination_backup_vault" {
+  provider                 = aws.osaka
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  description              = "Default key that protects my Backup data when no other key is defined"
+  enable_key_rotation      = true
+  is_enabled               = true
+  key_usage                = "ENCRYPT_DECRYPT"
+  multi_region             = false
+  policy = jsonencode(
+    {
+      Id = "auto-backup-1"
+      Statement = [
+        {
+          Action = [
+            "kms:CreateGrant",
+            "kms:Decrypt",
+            "kms:GenerateDataKey*",
+          ]
+          Condition = {
+            StringEquals = {
+              "kms:CallerAccount" = "${data.aws_caller_identity.current.account_id}"
+              "kms:ViaService"    = "backup.ap-northeast-3.amazonaws.com"
+            }
+          }
+          Effect = "Allow"
+          Principal = {
+            AWS = "*"
+          }
+          Resource = "*"
+          Sid      = "Allow access through Backup for all principals in the account that are authorized to use Backup Storage"
+        },
+        {
+          Action = [
+            "kms:Describe*",
+            "kms:Get*",
+            "kms:List*",
+            "kms:RevokeGrant",
+          ]
+          Effect = "Allow"
+          Principal = {
+            AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+          }
+          Resource = "*"
+          Sid      = "Allow direct access to key metadata to the account"
+        },
+      ]
+      Version = "2012-10-17"
+    }
+  )
+  tags     = {}
+  tags_all = {}
+}


### PR DESCRIPTION
## 概要
DynamoDBに対するAWS Backupの構築

## 仕様
## バックアッププラン

### バックアップルール

- ポイントタイムリカバリ (PITR)のために継続的なバックアップを有効化
- コールドストレージへの移行はするか？
- クロスリージョンのバックアップは `大阪`リージョン
- バックアップウィンドウ
    - 開始時間→PM07:00 UTC
    - 次の時間以内に開始→1時間
    - 次の時間以内に完了→2時間
- スケジュール
    - 毎日
    

### バックアップリソースの割り当てとサービスのオプトイン

- DynamoDBのみ指定
- IAM roleはDefaultのものを利用

### バックアップボールト

- DynamoDB用のバックアップボールトとデスティネーションバックアップボールトを作成
- defaultのKMSキーを暗号化キーとして利用する