### PR TITLE
add: elasticacheの追加

### DIFF
--- a/ap-northeast-1/dev/cloudwatch_logs.tf
+++ b/ap-northeast-1/dev/cloudwatch_logs.tf
@@ -1,7 +1,15 @@
 resource "aws_cloudwatch_log_group" "push_notification_batch" {
-  name = "/aws/batch/push_notification/job"
+  name = "/aws-batch/${var.env}/push_notification/job"
 }
 
 resource "aws_cloudwatch_log_group" "public_batch" {
-  name = "/aws/batch/public/job"
+  name = "/aws-batch/${var.env}/public/job"
+}
+
+resource "aws_cloudwatch_log_group" "redis_engine_logs" {
+  name = "redis/${var.env}/engine-logs"
+}
+
+resource "aws_cloudwatch_log_group" "redis_slow_logs" {
+  name = "redis/${var.env}/slow-logs"
 }

--- a/ap-northeast-1/dev/elasticache.tf
+++ b/ap-northeast-1/dev/elasticache.tf
@@ -1,0 +1,57 @@
+resource "aws_elasticache_replication_group" "main" {
+  replication_group_id = "${var.project_name}-${var.env}-redis"
+  description          = "Redis Replication Group for multi-region"
+  engine               = "redis"
+  port                 = 6379
+  node_type            = "cache.t4g.small"
+  security_group_ids = [
+    aws_security_group.elasticache_sg.id
+  ]
+  automatic_failover_enabled = false
+  multi_az_enabled           = false
+  parameter_group_name       = aws_elasticache_parameter_group.main.name
+  subnet_group_name          = aws_elasticache_subnet_group.main.name
+
+  num_cache_clusters = 2
+
+  maintenance_window       = "fri:13:30-fri:14:30"
+  snapshot_retention_limit = "1"
+  snapshot_window          = "16:00-17:00"
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.redis_engine_logs.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "engine-log"
+  }
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.redis_slow_logs.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "slow-log"
+  }
+
+  tags = {
+    "Name" = "${var.project_name}-${var.env}-elasticache_replication_group"
+  }
+}
+
+resource "aws_elasticache_subnet_group" "main" {
+  name        = "${var.env}-elasticache-subnet-group"
+  description = "ElastiCache subnet group for single AZ"
+
+  subnet_ids = [
+    aws_subnet.elastic_private_a.id
+  ]
+}
+
+resource "aws_elasticache_parameter_group" "main" {
+  name   = "${var.env}-elasticache-parameter-group"
+  family = "redis7"
+
+  parameter {
+    name  = "cluster-enabled"
+    value = "no"
+  }
+}

--- a/ap-northeast-1/dev/network.tf
+++ b/ap-northeast-1/dev/network.tf
@@ -109,6 +109,26 @@ resource "aws_subnet" "aws_batch_private_a" {
 #   }
 # }
 
+resource "aws_subnet" "elastic_private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.2.30.0/24"
+  availability_zone = "${var.region}a"
+
+  tags = {
+    Name = "${var.env}-elastic-private-a-sbn"
+  }
+}
+
+resource "aws_subnet" "elastic_private_c" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.2.31.0/24"
+  availability_zone = "${var.region}c"
+
+  tags = {
+    Name = "${var.env}-elastic-private-c-sbn"
+  }
+}
+
 
 # Internet Gateway
 resource "aws_internet_gateway" "main" {
@@ -253,6 +273,16 @@ resource "aws_route_table_association" "aws_batch_private_a" {
 #   route_table_id = aws_route_table.private_c.id
 # }
 
+resource "aws_route_table_association" "elastic_private_a" {
+  subnet_id      = aws_subnet.elastic_private_a.id
+  route_table_id = aws_route_table.private_a.id
+}
+
+# resource "aws_route_table_association" "elastic_private_c" {
+#   subnet_id      = aws_subnet.elastic_private_c.id
+#   route_table_id = aws_route_table.private_c.id
+# }
+
 # security_group
 #=======privateサブネットにLambdaを設定する際に必要なSecurity Group=========
 # resource "aws_security_group" "vpc_endpoint_of_interface_lambda_sg" {
@@ -387,6 +417,20 @@ resource "aws_security_group" "vpc_endpoint_cloudwatch_logs_sg" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "elasticache_sg" {
+  name        = "${var.env}-elasticache-sg"
+  description = "${var.env}-elasticache-sg"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "from public lambda"
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.from_api_gateway_to_lambda_sg.id}"]
   }
 }
 


### PR DESCRIPTION
## 概要
Elasticacheの追加

##  インスタンスタイプの選択についての説明

## 計算方法



キャッシュノードタイプ | vCPU | メモリ | ネットワークパフォーマンス | 時間あたりの料金
-- | -- | -- | -- | --
cache.t4g.micro | 2 | 0.5 GiB | 最大 5 ギガビット | 0.025USD
cache.t4g.small | 2 | 1.37 GiB | 最大 5 ギガビット | 0.049USD
cache.t4g.medium | 2 | 3.09 GiB | 最大 5 ギガビット | 0.098USD
cache.t3.micro | 2 | 0.5 GiB | 最大 5 ギガビット | 0.026USD
cache.t3.small | 2 | 1.37 GiB | 最大 5 ギガビット | 0.052USD
cache.t3.medium | 2 | 3.09 GiB | 最大 5 ギガビット | 0.103USD
cache.t2.micro | 1 | 0.555 GiB | 低～中 | 0.026USD
cache.t2.small | 1 | 1.55 GiB | 低～中 | 0.052USD



### `1アメリカ合衆国ドルが149.86円` の時の1日あたりの上限は以下の計算

2万円の1ヶ月あたりの上限を1日に換算すると、 `20,000円 ÷ 30日 = 666.67円/日` 。

2台のノードの合計で上記の上限以内にする。

1台あたりの上限は `666.67円 ÷ 2 = 333.33円/日` とする。

各インスタンスタイプの1日あたりの料金を日本円で計算する。

1. cache.t4g.micro: $0.025 × 24時間 × 149.86円 = 89.91円/日
2. cache.t4g.small: $0.049 × 24時間 × 149.86円 = 176.27円/日
3. cache.t4g.medium: $0.098 × 24時間 × 149.86円 = 352.54円/日
4. cache.t3.micro: $0.026 × 24時間 × 149.86円 = 93.58円/日
5. cache.t3.small: $0.052 × 24時間 × 149.86円 = 187.15円/日
6. cache.t3.medium: $0.103 × 24時間 × 149.86円 = 370.32円/日
7. cache.t2.micro: $0.026 × 24時間 × 149.86円 = 93.58円/日
8. cache.t2.small: $0.052 × 24時間 × 149.86円 = 187.15円/日

この中で、1日あたりの1台あたりの上限が333.33円/日以下のインスタンスタイプは以下の通り：

- cache.t4g.micro
- cache.t4g.small
- cache.t3.micro
- cache.t3.small
- cache.t2.micro
- cache.t2.small

上記のインスタンスタイプから、最もメモリやvCPUが高いものがcache.t4g.smallとcache.t3.small。一方、コストを最も抑えたい場合はcache.t4g.microやcache.t3.microを選択する。

**`cache.t4g.small`**と**`cache.t3.small`**は、キャッシュノードのスペックに関しては、vCPUとメモリの面では同じ。しかし、ノードタイプの名前や時間あたりの料金に違いが見られる。

主な違いを以下：

1. **インスタンス世代**: **`t4g`**は**`t3`**よりも新しい世代のインスタンスタイプを示している。新しい世代のインスタンスは、通常、改善されたパフォーマンスや追加の機能を持つことが多い。
2. **アーキテクチャ**: **`t4g`**シリーズはGraviton2ベースのインスタンス。Graviton2は、AWSが開発したARMベースのプロセッサ。**`t3`**シリーズは、IntelまたはAMDベースのプロセッサを使用している。ARMベースのインスタンスは、一般的にコスト効率が良く、高いパフォーマンスを持っているとされている。
3. **コスト**: **`cache.t4g.small`**は時間あたり$0.049で、**`cache.t3.small`**は時間あたり$0.052となっている。**`t4g`**がやや低コスト。
4. **ネットワークパフォーマンス**: 両方とも「最大 5 ギガビット」と記載されているので、この点では差異はない。

総じて、同じvCPUとメモリを持ちながら、**`cache.t4g.small`**がやや低コストであること、またGraviton2ベースであることが主な違いとして挙げられる。そのため、特定のアプリケーションでARMベースのプロセッサに互換性の問題がない場合、**`cache.t4g.small`**を選択することでコストを節約することができる可能性がある。

- 参考資料
https://aws.amazon.com/jp/elasticache/pricing/